### PR TITLE
feat: Fix No name for verifier node, add verifier account

### DIFF
--- a/backend/common/src/node_message.rs
+++ b/backend/common/src/node_message.rs
@@ -127,6 +127,8 @@ pub struct VerifierNodeDetails {
     pub layer2_app_id: u32,
     /// The verifier public key.
     pub verifier: Box<str>,
+    /// The name of the verifier node.
+    pub name: Box<str>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/backend/common/src/node_types.rs
+++ b/backend/common/src/node_types.rs
@@ -96,7 +96,7 @@ pub struct NodeHwBench {
 }
 
 /// The Details info for a alt-verifier node.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct VerifierNodeDetails {
     /// The layer1 chain 's genesis.
     pub layer1_genesis_hash: BlockHash,
@@ -106,6 +106,8 @@ pub struct VerifierNodeDetails {
     pub layer2_app_id: u32,
     /// The verifier public key.
     pub verifier: Box<str>,
+    /// The name of the verifier node.
+    pub name: Box<str>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -555,6 +555,13 @@ impl InnerLoop {
                             if node.stale() {
                                 feed_serializer.push(feed_message::StaleNode(node_id));
                             }
+
+                            if let Some(verifier_details) = node.verifier_details() {
+                                feed_serializer.push(feed_message::VerifierNodeDetailsStats(
+                                    node_id,
+                                    verifier_details,
+                                ));
+                            }
                         }
                         feed_serializer.into_finalized()
                     })

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -142,6 +142,7 @@ actions! {
     82: VerifierNodeChallengedBlockStats<'_>,
     83: VerifierNodeSubmissionPeriodStats,
     84: VerifierNodeChallengePeriodStats,
+    85: VerifierNodeDetailsStats<'_>,
 }
 
 #[derive(Serialize)]

--- a/backend/telemetry_core/src/feed_verifier_message.rs
+++ b/backend/telemetry_core/src/feed_verifier_message.rs
@@ -4,6 +4,7 @@
 use crate::feed_message::*;
 use common::node_types::{
     AppPeriod, BlockDetails, BlockHash, BlockNumber, NodeIO, NodeStats, VerifierBlockInfos,
+    VerifierNodeDetails,
 };
 use serde::{Deserialize, Serialize};
 
@@ -57,3 +58,6 @@ pub struct VerifierNodeSubmissionPeriodStats(pub FeedNodeId, pub AppPeriod);
 
 #[derive(Serialize)]
 pub struct VerifierNodeChallengePeriodStats(pub FeedNodeId, pub AppPeriod);
+
+#[derive(Serialize)]
+pub struct VerifierNodeDetailsStats<'a>(pub FeedNodeId, pub &'a VerifierNodeDetails);

--- a/backend/telemetry_core/src/state/chain.rs
+++ b/backend/telemetry_core/src/state/chain.rs
@@ -251,6 +251,13 @@ impl Chain {
                     self.stats_collator
                         .update_hwbench(node.hwbench(), CounterValue::Increment);
                 }
+                Payload::VerifierNodeDetails(ref details) => {
+                    if node.update_verifier_details(details) {
+                        if let Some(details) = node.verifier_details() {
+                            feed.push(feed_message::VerifierNodeDetailsStats(nid.into(), details));
+                        }
+                    }
+                }
                 Payload::VerifierDetailsStats(ref details) => {
                     if let (
                         Some(submitted_digest),

--- a/backend/telemetry_core/src/state/node.rs
+++ b/backend/telemetry_core/src/state/node.rs
@@ -15,10 +15,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::find_location;
-use common::node_message::SystemInterval;
+use common::node_message::{SystemInterval, VerifierNodeDetails};
 use common::node_types::{
     AppPeriod, Block, BlockDetails, NodeDetails, NodeHardware, NodeHwBench, NodeIO, NodeLocation,
-    NodeStats, Timestamp, VerifierBlockInfos, VerifierNodeDetails, VerifierStats,
+    NodeStats, Timestamp, VerifierBlockInfos, VerifierNodeDetails as VerifierNodeDetailsState,
+    VerifierStats,
 };
 use common::time;
 
@@ -51,7 +52,7 @@ pub struct Node {
     /// Hardware benchmark results for the node
     hwbench: Option<NodeHwBench>,
     /// The Static datas for verifier.
-    verifier_details: Option<VerifierNodeDetails>,
+    verifier_details: Option<VerifierNodeDetailsState>,
     /// The State datas for verifier.
     verifier_stats: VerifierStats,
 }
@@ -244,12 +245,20 @@ impl Node {
         self.startup_time
     }
 
-    pub fn verifier_details(&self) -> Option<&VerifierNodeDetails> {
+    pub fn verifier_details(&self) -> Option<&VerifierNodeDetailsState> {
         self.verifier_details.as_ref()
     }
 
-    pub fn update_verifier_details(&mut self, details: VerifierNodeDetails) -> bool {
+    pub fn update_verifier_details(&mut self, details: &VerifierNodeDetails) -> bool {
         if self.verifier_details.is_none() {
+            let details = VerifierNodeDetailsState {
+                layer1_genesis_hash: details.layer1_genesis_hash,
+                layer2_genesis_hash: details.layer2_genesis_hash,
+                layer2_app_id: details.layer2_app_id,
+                verifier: details.verifier.clone(),
+                name: details.name.clone(),
+            };
+
             self.verifier_details = Some(details);
             true
         } else {

--- a/backend/telemetry_shard/src/json_message/alt_verifier.rs
+++ b/backend/telemetry_shard/src/json_message/alt_verifier.rs
@@ -15,6 +15,8 @@ pub struct VerifierNodeDetails {
     pub layer2_app_id: u32,
     /// The verifier public key.
     pub verifier: Box<str>,
+    /// The name of the verifier node.
+    pub name: Box<str>,
 }
 
 impl From<VerifierNodeDetails> for internal::VerifierNodeDetails {
@@ -24,6 +26,7 @@ impl From<VerifierNodeDetails> for internal::VerifierNodeDetails {
             layer2_genesis_hash: msg.layer2_genesis_hash.into(),
             layer2_app_id: msg.layer2_app_id,
             verifier: msg.verifier,
+            name: msg.name,
         }
     }
 }

--- a/backend/telemetry_shard/src/main.rs
+++ b/backend/telemetry_shard/src/main.rs
@@ -323,22 +323,23 @@ where
                 // Deserialize from JSON, warning in debug mode if deserialization fails:
                 let node_message: json_message::NodeMessage = match serde_json::from_slice(&bytes) {
                     Ok(node_message) => node_message,
+                    #[cfg(debug)]
                     Err(e) => {
                         let bytes: &[u8] = bytes.get(..512).unwrap_or_else(|| &bytes);
                         let msg_start = std::str::from_utf8(bytes).unwrap_or_else(|_| "INVALID UTF8");
                         log::warn!("Failed to parse node message ({msg_start}): {e}");
                         continue;
+                    },
+                    #[cfg(not(debug))]
+                    Err(_) => {
+                        continue;
                     }
                 };
-
-                log::info!("node_message {:?}", node_message);
 
                 // Pull relevant details from the message:
                 let node_message: node_message::NodeMessage = node_message.into();
                 let message_id = node_message.id();
                 let payload = node_message.into_payload();
-
-                log::info!("node_message payload {:?}", payload);
 
                 // Until the aggregator receives an `Add` message, which we can create once
                 // we see one of these SystemConnected ones, it will ignore messages with

--- a/backend/telemetry_shard/src/main.rs
+++ b/backend/telemetry_shard/src/main.rs
@@ -323,23 +323,22 @@ where
                 // Deserialize from JSON, warning in debug mode if deserialization fails:
                 let node_message: json_message::NodeMessage = match serde_json::from_slice(&bytes) {
                     Ok(node_message) => node_message,
-                    #[cfg(debug)]
                     Err(e) => {
                         let bytes: &[u8] = bytes.get(..512).unwrap_or_else(|| &bytes);
                         let msg_start = std::str::from_utf8(bytes).unwrap_or_else(|_| "INVALID UTF8");
                         log::warn!("Failed to parse node message ({msg_start}): {e}");
                         continue;
-                    },
-                    #[cfg(not(debug))]
-                    Err(_) => {
-                        continue;
                     }
                 };
+
+                log::info!("node_message {:?}", node_message);
 
                 // Pull relevant details from the message:
                 let node_message: node_message::NodeMessage = node_message.into();
                 let message_id = node_message.id();
                 let payload = node_message.into_payload();
+
+                log::info!("node_message payload {:?}", payload);
 
                 // Until the aggregator receives an `Add` message, which we can create once
                 // we see one of these SystemConnected ones, it will ignore messages with

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,6 +73,7 @@ export default class App extends React.Component {
         blockpropagation: true,
         blocklasttime: false,
         uptime: false,
+        verifier: true,
       },
       (settings) => {
         const selectedColumns = this.selectedColumns(settings);
@@ -169,7 +170,12 @@ export default class App extends React.Component {
     return (
       <div className="App">
         <OfflineIndicator status={status} />
-        <Header chains={chains} connection={this.connection} subscribed={subscribed} subscribedData={subscribedData} />
+        <Header
+          chains={chains}
+          connection={this.connection}
+          subscribed={subscribed}
+          subscribedData={subscribedData}
+        />
         <Chain
           appState={this.appState}
           appUpdate={this.appUpdate}

--- a/frontend/src/Connection.ts
+++ b/frontend/src/Connection.ts
@@ -353,14 +353,20 @@ export class Connection {
         case ACTIONS.SubmittedBlock: {
           const [blockNumber, blockHash] = message.payload;
 
-          this.appUpdate({ submittedBlockHash: blockHash, submittedBlockNumber: blockNumber });
+          this.appUpdate({
+            submittedBlockHash: blockHash,
+            submittedBlockNumber: blockNumber,
+          });
           break;
         }
 
         case ACTIONS.ChallengedBlock: {
           const [blockNumber, blockHash] = message.payload;
 
-          this.appUpdate({ challengedBlockHash:  blockHash, challengedBlockNumber: blockNumber })
+          this.appUpdate({
+            challengedBlockHash: blockHash,
+            challengedBlockNumber: blockNumber,
+          });
           break;
         }
 
@@ -372,22 +378,18 @@ export class Connection {
         }
 
         case ACTIONS.Layer1ImportedBlock: {
-
           break;
         }
 
         case ACTIONS.Layer1FinalizedBlock: {
-
           break;
         }
 
         case ACTIONS.Layer1NodeStatsUpdate: {
-
           break;
         }
 
         case ACTIONS.Layer1NodeIOUpdate: {
-
           break;
         }
 
@@ -401,51 +403,64 @@ export class Connection {
           const [, blockNumber, blockHash] = message.payload;
           nodes.mutEach((node) => node.newBestBlock());
 
-          this.appUpdate({l2FinalizedBlockHash: blockHash, l2FinalizedBlockNumber: blockNumber });
+          this.appUpdate({
+            l2FinalizedBlockHash: blockHash,
+            l2FinalizedBlockNumber: blockNumber,
+          });
           break;
         }
 
         case ACTIONS.Layer2NodeStatsUpdate: {
-
           break;
         }
 
         case ACTIONS.Layer2NodeIOUpdate: {
-
           break;
         }
 
         case ACTIONS.VerifierNodeSubmittedBlockStats: {
-          const [, {
-            digest,
-            block_number,
-            block_hash,
-          }
-          ] = message.payload;
+          const [, { digest, block_number, block_hash }] = message.payload;
 
-          this.appUpdate({ submittedBlockHash: block_hash, submittedBlockNumber: block_number, submittedDigestHash: digest });
+          this.appUpdate({
+            submittedBlockHash: block_hash,
+            submittedBlockNumber: block_number,
+            submittedDigestHash: digest,
+          });
 
           break;
         }
 
         case ACTIONS.VerifierNodeChallengedBlockStats: {
-          const [, {
-            digest,
-            block_number,
-            block_hash,
-          }
-          ] = message.payload;
-          this.appUpdate({ challengedBlockHash: block_hash, challengedBlockNumber: block_number, challengedDigestHash: digest });
+          const [, { digest, block_number, block_hash }] = message.payload;
+          this.appUpdate({
+            challengedBlockHash: block_hash,
+            challengedBlockNumber: block_number,
+            challengedDigestHash: digest,
+          });
 
           break;
         }
 
         case ACTIONS.VerifierNodeSubmissionPeriodStats: {
-
           break;
         }
 
         case ACTIONS.VerifierNodeChallengePeriodStats: {
+          break;
+        }
+
+        case ACTIONS.VerifierNodeDetailsStats: {
+          console.log(
+            'VerifierNodeDetailsStats : ' + JSON.stringify(message.payload)
+          );
+
+          const [id, details] = message.payload;
+
+          nodes.mutAndMaybeSort(
+            id,
+            (node) => node.updateVerifierNodeDetails(details),
+            sortByColumn === LocationColumn
+          );
 
           break;
         }

--- a/frontend/src/Connection.ts
+++ b/frontend/src/Connection.ts
@@ -1,4 +1,3 @@
-import { DigestHash } from './common/types';
 // Source code for the Substrate Telemetry Server.
 // Copyright (C) 2021 Parity Technologies (UK) Ltd.
 //

--- a/frontend/src/common/feed.ts
+++ b/frontend/src/common/feed.ts
@@ -40,6 +40,7 @@ import {
   ChainStats,
   AppPeriod,
   VerifierBlockInfos,
+  VerifierNodeDetailInfos,
 } from './types';
 
 export const ACTIONS = {
@@ -81,6 +82,7 @@ export const ACTIONS = {
   VerifierNodeChallengedBlockStats: 0x52 as const,
   VerifierNodeSubmissionPeriodStats: 0x53 as const,
   VerifierNodeChallengePeriodStats: 0x54 as const,
+  VerifierNodeDetailsStats: 0x55 as const,
 };
 
 export type Action = typeof ACTIONS[keyof typeof ACTIONS];
@@ -291,6 +293,10 @@ interface VerifierNodeChallengePeriodStats extends MessageBase {
   payload: [NodeId, AppPeriod];
 }
 
+interface VerifierNodeDetailsStats extends MessageBase {
+  action: typeof ACTIONS.VerifierNodeDetailsStats;
+  payload: [NodeId, VerifierNodeDetailInfos];
+}
 
 export type Message =
   | FeedVersionMessage
@@ -330,7 +336,8 @@ export type Message =
   | VerifierNodeSubmittedBlockStats
   | VerifierNodeChallengedBlockStats
   | VerifierNodeSubmissionPeriodStats
-  | VerifierNodeChallengePeriodStats;
+  | VerifierNodeChallengePeriodStats
+  | VerifierNodeDetailsStats;
 
 /**
  * Data type to be sent to the feed. Passing through strings means we can only serialize once,

--- a/frontend/src/common/types.ts
+++ b/frontend/src/common/types.ts
@@ -45,12 +45,14 @@ export type NetworkId = Opaque<string, 'NetworkId'>;
 
 // for verifier
 export type AppPeriod = Opaque<number, 'AppPeriod'>;
+export type AppId = Opaque<number, 'AppId'>;
 export type DigestHash = Opaque<string, 'DigestHash'>;
+export type VerifierAccountId = Opaque<string, 'VerifierAccountId'>;
 export type VerifierBlockInfos = {
-  digest: DigestHash,
-  block_number: BlockNumber,
-  block_hash: BlockHash,
-}
+  digest: DigestHash;
+  block_number: BlockNumber;
+  block_hash: BlockHash;
+};
 
 export type BlockDetails = [
   BlockNumber,
@@ -120,4 +122,12 @@ export type ChainStats = {
   memory_memcpy_score: Maybe<Ranking<Range>>;
   disk_sequential_write_score: Maybe<Ranking<Range>>;
   disk_random_write_score: Maybe<Ranking<Range>>;
+};
+
+export type VerifierNodeDetailInfos = {
+  layer1_genesis_hash: GenesisHash;
+  layer2_genesis_hash: GenesisHash;
+  layer2_app_id: AppId;
+  verifier: VerifierAccountId;
+  name: NodeName;
 };

--- a/frontend/src/components/Chain/Chain.tsx
+++ b/frontend/src/components/Chain/Chain.tsx
@@ -66,7 +66,16 @@ export class Chain extends React.Component<ChainProps, ChainState> {
 
   public render() {
     const { appState } = this.props;
-    const { l2FinalizedBlockHash, l2FinalizedBlockNumber, submittedDigestHash, submittedBlockHash, submittedPeriod, challengedDigestHash, challengedBlockHash, challengedPeriod } = appState;
+    const {
+      l2FinalizedBlockHash,
+      l2FinalizedBlockNumber,
+      submittedDigestHash,
+      submittedBlockHash,
+      submittedPeriod,
+      challengedDigestHash,
+      challengedBlockHash,
+      challengedPeriod,
+    } = appState;
     const { display: currentTab } = this.state;
 
     return (

--- a/frontend/src/components/Chain/Header.css
+++ b/frontend/src/components/Chain/Header.css
@@ -20,7 +20,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
   width: 100%;
   height: 150px;
   overflow: hidden;
-  background: linear-gradient(0deg,#17171c, #000000);
+  background: linear-gradient(0deg, #17171c, #000000);
   color: white;
   min-width: 1350px;
   position: relative;

--- a/frontend/src/components/Chain/Header.tsx
+++ b/frontend/src/components/Chain/Header.tsx
@@ -15,10 +15,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import * as React from 'react';
-import { Types, Maybe } from '../../common';
-import { formatNumber, secondsWithPrecision } from '../../utils';
+import { Types } from '../../common';
+import { formatNumber } from '../../utils';
 import { ChainDisplay } from './';
-import { Tile, Ago } from '../';
+import { Tile } from '../';
 
 import l2FinalIcon from '../../icons/l2-final.svg';
 import submittedDigestIcon from '../../icons/l1-submitted-digest.svg';

--- a/frontend/src/components/Chain/Header.tsx
+++ b/frontend/src/components/Chain/Header.tsx
@@ -46,14 +46,14 @@ const Labeled = styled('div')`
 `;
 
 interface HeaderProps {
-  l2FinalizedBlockNumber: Types.BlockNumber,
-  l2FinalizedBlockHash: Types.BlockHash,
-  submittedDigestHash: Types.DigestHash,
-  submittedBlockHash: Types.BlockHash,
-  challengedBlockHash: Types.BlockHash,
-  challengedDigestHash: Types.DigestHash,
-  submittedPeriod: Types.AppPeriod,
-  challengedPeriod: Types.AppPeriod,
+  l2FinalizedBlockNumber: Types.BlockNumber;
+  l2FinalizedBlockHash: Types.BlockHash;
+  submittedDigestHash: Types.DigestHash;
+  submittedBlockHash: Types.BlockHash;
+  challengedBlockHash: Types.BlockHash;
+  challengedDigestHash: Types.DigestHash;
+  submittedPeriod: Types.AppPeriod;
+  challengedPeriod: Types.AppPeriod;
   currentTab: ChainDisplay;
 }
 
@@ -86,25 +86,56 @@ export class Header extends React.Component<HeaderProps> {
 
     return (
       <div className="Header">
-        <Tile icon={l2FinalIcon} title="L2 finalize block & hash" suffix={<p style={{
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-          textOverflow: 'ellipsis',
-          fontSize: '14px'
-        }}>{l2FinalizedBlockHash}</p>}>
+        <Tile
+          icon={l2FinalIcon}
+          title="L2 finalize block & hash"
+          suffix={
+            <p
+              style={{
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+                fontSize: '14px',
+              }}
+            >
+              {l2FinalizedBlockHash}
+            </p>
+          }
+        >
           #{formatNumber(l2FinalizedBlockNumber)}
         </Tile>
         <div className="divider" />
-        <Tile icon={submittedDigestIcon} title="L1 submitted digest" suffix={<Labeled><span className="title">Block hash</span>{submittedBlockHash}</Labeled>}>
+        <Tile
+          icon={submittedDigestIcon}
+          title="L1 submitted digest"
+          suffix={
+            <Labeled>
+              <span className="title">Block hash</span>
+              {submittedBlockHash}
+            </Labeled>
+          }
+        >
           {submittedDigestHash || '0x'}
         </Tile>
-        <Tile icon={chanllengedDigestIcon} title="L1 challenged digest" suffix={<Labeled><span className="title">Block hash</span>{challengedBlockHash}</Labeled>}>
+        <Tile
+          icon={chanllengedDigestIcon}
+          title="L1 challenged digest"
+          suffix={
+            <Labeled>
+              <span className="title">Block hash</span>
+              {challengedBlockHash}
+            </Labeled>
+          }
+        >
           {challengedDigestHash || '0x'}
         </Tile>
         <Tile icon={submissionAppPeriodIcon} title="L1 submission AppPeriod">
           {formatNumber(submittedPeriod)}
         </Tile>
-        <Tile icon={finishedChallengeAppPeriodIcon} title="L1 last finished challenge AppPeriod">
+        <Tile
+          icon={finishedChallengeAppPeriodIcon}
+          title="L1 last finished challenge AppPeriod"
+        >
           {formatNumber(challengedPeriod)}
         </Tile>
       </div>

--- a/frontend/src/components/Chains.css
+++ b/frontend/src/components/Chains.css
@@ -52,7 +52,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 }
 
 .Chains-all-chains {
-
 }
 
 .Chains-fork-me {
@@ -111,7 +110,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 .Chains-chain.Chains-chain-selected {
   color: white;
   font-weight: bold;
-  background-color: #6667AB;
+  background-color: #6667ab;
   border-radius: 20px;
   /*
   Instead of making the font bold, which changes the container width and

--- a/frontend/src/components/Header/Github.tsx
+++ b/frontend/src/components/Header/Github.tsx
@@ -2,13 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import GithubSvg from './github.svg';
 
-const Github: React.FC<{className?: string}> = ({ className }) => {
-  return (
-    <img className={className} src={GithubSvg} />
-  );
+const Github: React.FC<{ className?: string }> = ({ className }) => {
+  return <img className={className} src={GithubSvg} />;
 };
 
-
-export default styled(Github)`
-
-`;
+export default styled(Github)``;

--- a/frontend/src/components/Header/Logo.tsx
+++ b/frontend/src/components/Header/Logo.tsx
@@ -2,13 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import LogoSvg from './logo.svg';
 
-const Logo: React.FC<{className?: string}> = ({ className }) => {
-  return (
-    <img className={className} src={LogoSvg} />
-  );
+const Logo: React.FC<{ className?: string }> = ({ className }) => {
+  return <img className={className} src={LogoSvg} />;
 };
 
-
-export default styled(Logo)`
-
-`;
+export default styled(Logo)``;

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -40,7 +40,7 @@ const Header: React.FC<{
 export default styled(Header)`
   height: 112px;
   padding: 0px 24px;
-  background: linear-gradient(0deg,#000000 0%, #2f2e56 100%);
+  background: linear-gradient(0deg, #000000 0%, #2f2e56 100%);
 
   > .logo-container {
     height: 72px;

--- a/frontend/src/components/LinkSvg.tsx
+++ b/frontend/src/components/LinkSvg.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const LinkSvg: React.FC<{ className?: string; children: React.ReactNode; link?: string }> = ({ className, children, link }) => {
+const LinkSvg: React.FC<{
+  className?: string;
+  children: React.ReactNode;
+  link?: string;
+}> = ({ className, children, link }) => {
   return (
     <a className={className} href={link} target="_blank" rel="noreferrer">
       {children}
@@ -9,11 +13,10 @@ const LinkSvg: React.FC<{ className?: string; children: React.ReactNode; link?: 
   );
 };
 
-
 export default styled(LinkSvg)`
   svg:hover {
     path {
-      fill: #9B9CF8;
+      fill: #9b9cf8;
     }
   }
 `;

--- a/frontend/src/components/List/Column/Column.tsx
+++ b/frontend/src/components/List/Column/Column.tsx
@@ -38,6 +38,7 @@ import {
   BlockPropagationColumn,
   LastBlockColumn,
   UptimeColumn,
+  VerifierAccountColumn,
 } from './';
 
 export type Column =
@@ -58,7 +59,8 @@ export type Column =
   | typeof BlockTimeColumn
   | typeof BlockPropagationColumn
   | typeof LastBlockColumn
-  | typeof UptimeColumn;
+  | typeof UptimeColumn
+  | typeof VerifierAccountColumn;
 
 export interface ColumnProps {
   node: Node;

--- a/frontend/src/components/List/Column/VerifierAccountColumn.tsx
+++ b/frontend/src/components/List/Column/VerifierAccountColumn.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { ColumnProps } from './';
+import { Node } from '../../../state';
+import { PolkadotIcon, Tooltip, TooltipCopyCallback } from '../../';
+import icon from '../../../icons/shield.svg';
+import { Maybe } from '../../../common';
+
+export class VerifierAccountColumn extends React.Component<ColumnProps> {
+  public static readonly label = 'Verifier';
+  public static readonly icon = icon;
+  public static readonly setting = 'verifier';
+  public static readonly width = 16;
+  public static readonly sortBy = ({ verifier_account }: Node) =>
+    verifier_account || '';
+
+  private data: Maybe<string>;
+  private copy: Maybe<TooltipCopyCallback>;
+
+  public shouldComponentUpdate(nextProps: ColumnProps) {
+    // Node name only changes when the node does
+    return this.data !== nextProps.node.verifier_account;
+  }
+
+  render() {
+    const { verifier_account } = this.props.node;
+
+    console.log(verifier_account);
+    this.data = verifier_account;
+
+    if (!verifier_account) {
+      return <td className="Column">-</td>;
+    }
+
+    return (
+      <td className="Column" onClick={this.onClick}>
+        <Tooltip text={verifier_account} copy={this.onCopy} />
+        <PolkadotIcon
+          className="Column-verifier"
+          account={verifier_account}
+          size={16}
+        />
+      </td>
+    );
+  }
+
+  private onCopy = (copy: TooltipCopyCallback) => {
+    this.copy = copy;
+  };
+
+  private onClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+
+    if (this.copy != null) {
+      this.copy();
+    }
+  };
+}

--- a/frontend/src/components/List/Column/index.ts
+++ b/frontend/src/components/List/Column/index.ts
@@ -33,3 +33,6 @@ export * from './BlockTimeColumn';
 export * from './BlockPropagationColumn';
 export * from './LastBlockColumn';
 export * from './UptimeColumn';
+
+// for verifier
+export * from './VerifierAccountColumn';

--- a/frontend/src/components/List/Row.css
+++ b/frontend/src/components/List/Row.css
@@ -27,7 +27,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 }
 
 .Row-pinned td:first-child {
-  border-left: 3px solid #6667AB;
+  border-left: 3px solid #6667ab;
   padding-left: 10px;
 }
 

--- a/frontend/src/components/List/Row.tsx
+++ b/frontend/src/components/List/Row.tsx
@@ -38,6 +38,7 @@ import {
   BlockPropagationColumn,
   LastBlockColumn,
   UptimeColumn,
+  VerifierAccountColumn,
 } from './';
 
 import './Row.css';
@@ -55,6 +56,7 @@ interface RowState {
 export class Row extends React.Component<RowProps, RowState> {
   public static readonly columns: Column[] = [
     NameColumn,
+    VerifierAccountColumn,
     LocationColumn,
     ImplementationColumn,
     PeersColumn,

--- a/frontend/src/components/List/Row.tsx
+++ b/frontend/src/components/List/Row.tsx
@@ -21,12 +21,9 @@ import { PersistentSet } from '../../persist';
 import {
   Column,
   NameColumn,
-  ValidatorColumn,
   LocationColumn,
   ImplementationColumn,
-  NetworkIdColumn,
   PeersColumn,
-  TxsColumn,
   UploadColumn,
   DownloadColumn,
   StateCacheColumn,

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -25,11 +25,7 @@ interface TileProps {
 }
 
 function Tabs(props: TileProps) {
-  return (
-    <div className={props.className}>
-
-    </div>
-  );
+  return <div className={props.className}></div>;
 }
 
 export default Tabs;

--- a/frontend/src/components/Tile.tsx
+++ b/frontend/src/components/Tile.tsx
@@ -30,9 +30,11 @@ export function Tile(props: TileProps) {
     <div className="Tile">
       <Icon src={props.icon} />
       <div>
-        {
-          typeof props.title === 'string' ? <p className="Tile-label">{props.title}</p> : props.title
-         }
+        {typeof props.title === 'string' ? (
+          <p className="Tile-label">{props.title}</p>
+        ) : (
+          props.title
+        )}
         <p className="Tile-content">{props.children}</p>
         {props.suffix}
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -74,14 +74,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 * {
   /* Use "standard"/common sense heights/widths (ie they include padding+border) */
   box-sizing: border-box;
-  font-family: Kanit, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-family: Kanit, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }
 
 body {
   background: #17171c;
   margin: 0;
   padding: 0;
-  font-family: Kanit, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-family: Kanit, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }
 
 p {

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -56,14 +56,15 @@ export class Node {
   }
 
   public readonly id: Types.NodeId;
-  public readonly name: Types.NodeName;
+  // will change by notification.
+  public name: Types.NodeName;
   public readonly implementation: Types.NodeImplementation;
   public readonly version: Types.NodeVersion;
   public readonly validator: Maybe<Types.Address>;
   public readonly networkId: Maybe<Types.NetworkId>;
   public readonly startupTime: Maybe<Types.Timestamp>;
 
-  public readonly sortableName: string;
+  public sortableName: string;
   public readonly sortableVersion: number;
 
   public stale: boolean;
@@ -83,6 +84,12 @@ export class Node {
 
   public finalized = 0 as Types.BlockNumber;
   public finalizedHash = '' as Types.BlockHash;
+
+  // datas for verifier
+  public layer1_genesis_hash: Types.GenesisHash;
+  public layer2_genesis_hash: Types.GenesisHash;
+  public layer2_app_id: Types.AppId;
+  public verifier_account: Types.VerifierAccountId;
 
   public lat: Maybe<Types.Latitude>;
   public lon: Maybe<Types.Longitude>;
@@ -186,6 +193,18 @@ export class Node {
     this.trigger();
   }
 
+  public updateVerifierNodeDetails(details: Types.VerifierNodeDetailInfos) {
+    console.log('update details: ', details);
+    this.layer2_app_id = details.layer2_app_id;
+    this.layer1_genesis_hash = details.layer1_genesis_hash;
+    this.layer2_genesis_hash = details.layer2_genesis_hash;
+    this.verifier_account = details.verifier;
+    this.name = details.name;
+    this.sortableName = this.name.toLocaleLowerCase();
+
+    this.trigger();
+  }
+
   public newBestBlock() {
     if (this.propagationTime != null) {
       this.propagationTime = null;
@@ -255,12 +274,13 @@ export interface StateSettings {
   blockpropagation: boolean;
   blocklasttime: boolean;
   uptime: boolean;
+  verifier: boolean;
 }
 
 export interface State {
   status: 'online' | 'offline' | 'upgrade-requested';
-  l2FinalizedBlockNumber: Types.BlockNumber,
-  l2FinalizedBlockHash: Types.BlockHash,
+  l2FinalizedBlockNumber: Types.BlockNumber;
+  l2FinalizedBlockHash: Types.BlockHash;
   submittedBlockNumber: Types.BlockNumber;
   submittedBlockHash: Types.BlockHash;
   submittedDigestHash: Types.DigestHash;


### PR DESCRIPTION
Need wait [193](https://github.com/alt-research/alt-verifier/pull/193) merged.

- Add name in verifier-node-detail msg
- Add verifier account column in show